### PR TITLE
Hide comment in Humii theme header

### DIFF
--- a/site/themes/humii/header.php
+++ b/site/themes/humii/header.php
@@ -24,7 +24,7 @@
 				<div id="title">
 					<a href="<?php echo linkToSite(); ?>"><h1><?php echo siteTitle()?></h1></a>
 				</div>
-				<!-->
+				<!--
 				<div id="subtitle">
 					An optional subtitle.
 				</div>

--- a/system/modules/pages/pages_manage.php
+++ b/system/modules/pages/pages_manage.php
@@ -226,7 +226,7 @@
 		$manager->form->reset_template( "text_template" );
 		$manager->form->reset_template( "select_template" );
 		
-		$manager->form->message( 'Need help with this? Read the <a href="http://help.secretarycms.com/kb/faq/what-is-the-page-type-and-how-do-i-use-it" class="external">how to</a> in the User Guide.' );
+		$manager->form->message( 'Need help with this? Read the <a href="http://help.thesecretary.org/kb/faq/what-is-the-page-type-and-how-do-i-use-it" class="external">how to</a> in the User Guide.' );
 		
 		call_anchor( "pages_manage_after_type", $data );
 		


### PR DESCRIPTION
The extra `>` on line 27 breaks the comment that hides the optional subtitle and reveals a `-->`

I've wanted to fix this for ages and finally can, thanks to GitHub. Sweet!