### PR TITLE
multiple  sql vulnerabilities

### DIFF
--- a/install.php
+++ b/install.php
@@ -166,7 +166,7 @@
 						$manager->clerk->loadSettings();
 
 						# Setup user
-						$username	=	$_POST['username'];
+						$username	=	mysql_real_escape_string($_POST['username']);
 						$password	=	$_POST['password'];
 						$email		=	$_POST['email'];
 


### PR DESCRIPTION
Hi,
I found several SQL injection vulnerabilities inside install.php

Steps to reproduce:
1. Download and extract The-Secretary
2. call the install.php inside the browser
3. fill in all fields. For the username choose something like "newuser' or '1'='1" (w/o double quotations)
The resulting sql query will look like this:
SELECT COUNT(*) as numGrabbed FROM users WHERE username= 'newuser' or '1'='1'
Which will be executed in line 181 inside install.php.

4. Normally there should be a new user inside the users table. But as the sql query gets modified no user gets created.
Log in to the mysql database and check if there was indeed no new user created. 

5. To fix this vulnerability wrap the POST variables with mysql_real_escape_string

Also check other input variables for sanitation.